### PR TITLE
.gitignore: ignore dj_local_conf.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# datajoint
+dj_local_conf.json


### PR DESCRIPTION
should block user settings from making their way into the repository.