### PR TITLE
pipeline: update InsertBuffer & usage for dj.insert 'allow_errors' removal

### DIFF
--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -24,8 +24,7 @@ class InsertBuffer(object):
         self._queue += recs
 
     def flush(self, replace=False, skip_duplicates=False,
-              ignore_extra_fields=False, ignore_errors=False,
-              allow_direct_insert=False, chunksz=1):
+              ignore_extra_fields=False, allow_direct_insert=False, chunksz=1):
         '''
         flush the buffer
         XXX: use kwargs?
@@ -34,10 +33,10 @@ class InsertBuffer(object):
         qlen = len(self._queue)
         if qlen > 0 and qlen % chunksz == 0:
             try:
-                self._rel.insert(self._queue, skip_duplicates=skip_duplicates,
-                                 ignore_extra_fields=ignore_extra_fields,
-                                 ignore_errors=ignore_errors,
-                                 allow_direct_insert=allow_direct_insert)
+                self._rel().insert(self._queue,
+                                   skip_duplicates=skip_duplicates,
+                                   ignore_extra_fields=ignore_extra_fields,
+                                   allow_direct_insert=allow_direct_insert)
                 self._queue.clear()
                 return True
             except dj.DataJointError as e:

--- a/pipeline/ingest/ephys.py
+++ b/pipeline/ingest/ephys.py
@@ -15,7 +15,6 @@ from pipeline import ephys
 from pipeline import InsertBuffer
 from pipeline.ingest import behavior as ingest_behavior
 
-
 log = logging.getLogger(__name__)
 
 schema = dj.schema(dj.config.get(
@@ -232,7 +231,7 @@ class EphysIngest(dj.Imported):
             len_trial_units2 = len(trialunits2)
 
             for x in range(len_trial_units2):
-                ib.insert1(dict(ekey, unit = trialunits1[x], trial = trialunits2[x]))
+                ib.insert1(dict(ekey, unit=trialunits1[x], trial=trialunits2[x]))
 
                 if ib.flush(skip_duplicates=True, allow_direct_insert=True,
                             chunksz=10000):


### PR DESCRIPTION
Changes in datajoint head remove the .insert 'allow_errors' argument. 
This updates InsertBuffer and users of InsertBuffer accordingly.