### PR TITLE
pipeline/ccf.py: update CCFAnnotation to use index

### DIFF
--- a/pipeline/ccf.py
+++ b/pipeline/ccf.py
@@ -61,7 +61,8 @@ class CCFAnnotation(dj.Manual):
     -> CCF
     -> AnnotationType
     ---
-    annotation  : varchar(1200)
+    annotation  : varchar(1024)
+    index (annotation)
     """
 
     @classmethod


### PR DESCRIPTION
Due to the large number of records in CCF/CCFAnnotation table, 
searching via annotation is quite slow, but using a separate table is not desired for user-level
annotations since this makes usage cumbersome. Indexing the annotation field speeds this up significantly. Index required that the record length be downsized to 1024 characters from 1200.