### PR TITLE
workers debug update

### DIFF
--- a/pipeline/report.py
+++ b/pipeline/report.py
@@ -851,6 +851,7 @@ def delete_outdated_project_plots(project_name='MAP'):
 
     if plotted_track_count != latest_track_count:
         uuid_byte = (ProjectLevelProbeTrack & {'project_name': project_name}).proj(ub='(tracks_plot)').fetch1('ub')
+        print('uuid_byte:', str(uuid_byte))
         ext_key = {'hash': uuid.UUID(bytes=uuid_byte)}
 
         with dj.config(safemode=False):

--- a/pipeline/report.py
+++ b/pipeline/report.py
@@ -851,7 +851,7 @@ def delete_outdated_project_plots(project_name='MAP'):
 
     if plotted_track_count != latest_track_count:
         uuid_byte = (ProjectLevelProbeTrack & {'project_name': project_name}).proj(ub='(tracks_plot)').fetch1('ub')
-        print('uuid_byte:', str(uuid_byte))
+        print('project_name', project_name, 'uuid_byte:', str(uuid_byte))
         ext_key = {'hash': uuid.UUID(bytes=uuid_byte)}
 
         with dj.config(safemode=False):


### PR DESCRIPTION
print to assist debugging uuid errors:
```
map_workers_4          | All SessionLevelCDReport are up-to-date
map_workers_4          | ProjectLevelProbeTrack is up-to-date
map_workers_4          | Deleting 0 rows from `map_v2_ingest_ephys`.`_ephys_ingest`
map_workers_4          | Deleting 0 rows from `map_v2_ingest_tracking`.`_tracking_ingest`
map_workers_4          | Deleting 0 rows from `map_v2_ingest_histology`.`_histology_ingest`
map_workers_4          | Generated /data/report/v2/SC043/20200921_162104/SC043_20200921_162104_session_tracks_plot.png
map_workers_4          | Generated /data/report/v2/SC043/20200921_162104/1/SC043_20200921_162104_1_kilosort2_1_driftmap.png
map_workers_4          | Generated /data/report/v2/SC043/20200921_162104/1/SC043_20200921_162104_1_1_coronal_slice.png
map_workers_4          | All SessionLevelProbeTrack are up-to-date
map_workers_4          | All SessionLevelCDReport are up-to-date
map_workers_4          | Traceback (most recent call last):
map_workers_4          |   File "scripts/mapshell.py", line 22, in <module>
map_workers_4          |     shell.actions[action][0](*sys.argv[2:])
map_workers_4          |   File "/usr/local/lib/python3.6/dist-packages/pipeline/shell.py", line 476, in automate_computation
map_workers_4          |     report.delete_outdated_project_plots()
map_workers_4          |   File "/usr/local/lib/python3.6/dist-packages/pipeline/report.py", line 854, in delete_outdated_project_plots
map_workers_4          |     ext_key = {'hash': uuid.UUID(bytes=uuid_byte)}
map_workers_4          |   File "/usr/lib/python3.6/uuid.py", line 149, in __init__
map_workers_4          |     raise ValueError('bytes is not a 16-char string')```