### PR TITLE
ephys: add NIDQ events ingestion (trialevent, camera, zaber)

### DIFF
--- a/pipeline/ephys.py
+++ b/pipeline/ephys.py
@@ -200,6 +200,30 @@ class Unit(dj.Imported):
 
 
 @schema
+class TrialEventType(dj.Lookup):
+    definition = """
+    trial_event_type  : varchar(20)  
+    """
+    contents = zip(('bitcodestart', 'go', 'choice', 'reward', 'trialend',   # Same as experiment.TrialEvent; could be used for cross-validation
+                    'bpodstart', 'zaberstep', 'zaberinposition'    # Events that are only available from NIDQ channels (camera pulses into the tracking schema)
+                    ))   
+
+
+@schema
+class TrialEvent(dj.Imported):
+    """
+    Trialized events extracted from NIDQ channels with (global) session-based times
+    """
+    definition = """
+    -> experiment.BehaviorTrial
+    trial_event_id: smallint
+    ---
+    -> TrialEventType
+    trial_event_time : float  # (s) from session start (global time)
+    """    
+
+
+@schema
 class UnitNote(dj.Imported):
     definition = """
     -> Unit

--- a/pipeline/ephys.py
+++ b/pipeline/ephys.py
@@ -200,16 +200,6 @@ class Unit(dj.Imported):
 
 
 @schema
-class TrialEventType(dj.Lookup):
-    definition = """
-    trial_event_type  : varchar(20)  
-    """
-    contents = zip(('bitcodestart', 'go', 'choice', 'reward', 'trialend',   # Same as experiment.TrialEvent; could be used for cross-validation
-                    'bpodstart', 'zaberstep', 'zaberinposition'    # Events that are only available from NIDQ channels (camera pulses into the tracking schema)
-                    ))   
-
-
-@schema
 class TrialEvent(dj.Imported):
     """
     Trialized events extracted from NIDQ channels with (global) session-based times
@@ -218,7 +208,7 @@ class TrialEvent(dj.Imported):
     -> experiment.BehaviorTrial
     trial_event_id: smallint
     ---
-    -> TrialEventType
+    -> experiment.TrialEventType
     trial_event_time : float  # (s) from session start (global time)
     """    
 

--- a/pipeline/experiment.py
+++ b/pipeline/experiment.py
@@ -284,7 +284,7 @@ class TrialEventType(dj.Lookup):
     trial_event_type  : varchar(12)  
     """
     contents = zip(('delay', 'go', 'sample', 'presample', 'trialend',
-                    'videostart', 'bitcodestart', 'choice', 'reward', 'doubledip'))   # Added for foraging
+                    'videostart', 'videoend', 'bitcodestart', 'choice', 'reward', 'doubledip'))   # Added for foraging
 
 
 @schema

--- a/pipeline/experiment.py
+++ b/pipeline/experiment.py
@@ -284,7 +284,9 @@ class TrialEventType(dj.Lookup):
     trial_event_type  : varchar(12)  
     """
     contents = zip(('delay', 'go', 'sample', 'presample', 'trialend',
-                    'videostart', 'videoend', 'bitcodestart', 'choice', 'reward', 'doubledip'))   # Added for foraging
+                    'videostart', 'videoend', 'bitcodestart', 'choice', 'reward', 'doubledip',   # Added for foraging
+                    'bpodstart', 'zaberstep', 'zaberready'    # Events only available from NIDQ channels
+                    ))
 
 
 @schema

--- a/pipeline/ingest/behavior.py
+++ b/pipeline/ingest/behavior.py
@@ -691,7 +691,7 @@ class BehaviorBpodIngest(dj.Imported):
                 #    They are far from each other because I start the bpod trial at the middle of ITI (Foraging_bpod: e9a8ffd6) to cover video recording during ITI.
                 # 3. In theory, *bitcodestart* = *delay* (since there's no sample period),
                 #    but in practice, the bitcode (21*20=420 ms) and lickport movement (~100 ms) also take some time.
-                #    Note that bpod doesn't know the exact time when lickports are in place, so we can get *delay* only from NIDQ zaber channel.
+                #    Note that bpod doesn't know the exact time when lickports are in place, so we can get *delay* only from NIDQ zaber channel (ephys.TrialEvent.'zaberinposition').
                 # 4. In early lick trials, effective delay start should be the last 'DelayStart' (?)
                 # 5. Finally, to perform session-wise alignment between behavior and ephys, there are two ways, which could be cross-checked with each other:
                 #       (1) (most straightforward) use all event markers directly from NIDQ bitcode.mat,
@@ -717,6 +717,7 @@ class BehaviorBpodIngest(dj.Imported):
                                            'reward': [f'Reward_{lickport}' for lickport in self.water_port_name_mapper.values()],
                                            'doubledip': ['Double_dipped'],   # Only for non-double-dipped trials, ITI = last lick + 1 sec (maybe I should not use double dipping punishment for ehpys?)
                                            'trialend': ['ITI'],
+                                           'videoend': ['ITIAfterVideoOff'],
                                            }
 
                 for trial_event_type, bpod_state in bpod_states_of_interest.items():

--- a/pipeline/tracking.py
+++ b/pipeline/tracking.py
@@ -46,6 +46,13 @@ class Tracking(dj.Imported):
     ---
     tracking_samples: int             # number of events (possibly frame number, relative to the start of the trial)
     """
+    
+    class Frame(dj.Part):
+        definition = """
+        -> Tracking
+        ---
+        frame_time: longblob   # Global session-wise time (in sec)
+        """
 
     class NoseTracking(dj.Part):
         definition = """


### PR DESCRIPTION
1. add new tables to `ephys` for NIDQ trial events
2. add new part table to `tracking.Tracking` for camera feedback pulses
3. add `insert_ephys_events` to the ephys ingestion routine